### PR TITLE
DeletedMessage::getSendFromOrTo()がnullを返した場合にエラーが発生するのを避ける修正

### DIFF
--- a/lib/helper/opMessageHelper.php
+++ b/lib/helper/opMessageHelper.php
@@ -16,7 +16,7 @@
  * @author     Maki TAKAHASHI <takahashi@tejimaya.com>
  */
 
-function op_message_link_to_member(sfOutputEscaper $member)
+function op_message_link_to_member(sfOutputEscaper $member = null)
 {
   if (function_exists('op_link_to_member'))
   {


### PR DESCRIPTION
テスト添付してなくて申し訳ありませんが、発生した現象の詳細と経緯は公式SNSの下記トピックに記載されています。
http://sns.openpne.jp/communityTopic/8687

よろしくお願いいたします。
