### PR TITLE
 申請系のメッセージをPCで表示すると二重にHTMLエスケープされるバグの修正 (refs #3506)

### DIFF
--- a/lib/util/opMessageSender.class.php
+++ b/lib/util/opMessageSender.class.php
@@ -110,6 +110,9 @@ class opMessageSender
     $view = new opGlobalPartialView(sfContext::getInstance(), 'superGlobal', $templateName, '');
     $view->setPartialVars($templateParams);
 
+    // decorated message is not HTML
+    $view->getAttributeHolder()->setEscaping(false);
+
     return $view->render();
   }
 


### PR DESCRIPTION
Bug（バグ） #3506: 申請系のメッセージをPCで表示すると二重にHTMLエスケープされる - opMessagePlugin - OpenPNE Issue Tracking System
https://redmine.openpne.jp/issues/3506

の修正です。
