### PR TITLE
T3537 update category notification center

### DIFF
--- a/lib/util/opMessagePluginUtil.class.php
+++ b/lib/util/opMessagePluginUtil.class.php
@@ -23,7 +23,7 @@ class opMessagePluginUtil
 
     $message = sfContext::getInstance()->getI18n()->__('There are new %d messages!', array('%d' => 1));
 
-    opNotificationCenter::notify($fromMember, $toMember, $message, array('category' => 'other', 'url' => $url, 'icon_url' => null));
+    opNotificationCenter::notify($fromMember, $toMember, $message, array('category' => 'message', 'url' => $url, 'icon_url' => null));
   }
 }
 


### PR DESCRIPTION
通知センタの修正をプルリクエストします

Bug（バグ） #3537: メッセージの通知センタの情報が「＠」アイコンに対して表示されている - opMessagePlugin - OpenPNE Issue Tracking System
https://redmine.openpne.jp/issues/3537
