### PR TITLE
T3542 update smartphone subject for pc or mobile

### DIFF
--- a/apps/api/modules/message/actions/actions.class.php
+++ b/apps/api/modules/message/actions/actions.class.php
@@ -35,7 +35,7 @@ class messageActions extends opJsonApiActions
     $relation = Doctrine_Core::getTable('MemberRelationship')->retrieveByFromAndTo($toMember->getId(), $this->member->getId());
     $this->forward400If($relation && $relation->getIsAccessBlock(), 'Cannot send the message.');
 
-    $message = Doctrine::getTable('SendMessageData')->sendMessage($toMember, mb_substr($body, 0, 25), $body, array());
+    $message = Doctrine::getTable('SendMessageData')->sendMessage($toMember, SendMessageData::SMARTPHONE_SUBJECT, $body, array());
 
     $file = $request->getFiles('message_image');
     try

--- a/apps/mobile_frontend/i18n/messages.ja.xml
+++ b/apps/mobile_frontend/i18n/messages.ja.xml
@@ -118,6 +118,10 @@
         <source>Delete messages</source>
         <target>ﾒｯｾｰｼﾞを削除する</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>Message from smartphone</source>
+        <target>ｽﾏｰﾄﾌｫﾝからのﾒｯｾｰｼﾞ</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/i18n/messages.ja.xml
+++ b/i18n/messages.ja.xml
@@ -50,6 +50,10 @@
         <source>Do you delete messages?</source>
         <target>削除してよろしいですか？</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>Message from smartphone</source>
+        <target>スマートフォンからのメッセージ</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/lib/helper/opMessageHelper.php
+++ b/lib/helper/opMessageHelper.php
@@ -60,6 +60,7 @@ function op_api_message($messageList, $member, $useIsReadFlag = false)
     'member'      => op_api_member($member),
     'subject'     => $message->getSubject(),
     'body'        => nl2br($body),
+    'summary'     => op_truncate(op_decoration($body, true), 25, '...'),
     'image_path'  => $imagePath,
     'image_tag'   => $imageTag,
     'created_at'  => $message->getCreatedAt(),

--- a/lib/model/doctrine/PluginSendMessageData.class.php
+++ b/lib/model/doctrine/PluginSendMessageData.class.php
@@ -23,6 +23,8 @@ abstract class PluginSendMessageData extends BaseSendMessageData
   const MESSAGE_TYPE_DRAFT = 'draft';
   const MESSAGE_TYPE_DUST = 'dust';
 
+  const SMARTPHONE_SUBJECT = '%%%SMARTPHONE_SUBJECT%%%';
+
   protected
     $previous = null,
     $next = null;
@@ -191,5 +193,14 @@ abstract class PluginSendMessageData extends BaseSendMessageData
         ->where('m.message_id = ?', $this->id)
         ->execute();
     }
+  }
+
+  public function postHydrate($event)
+  {
+    $object = $event->data;
+    $replacement = sfContext::getInstance()->getI18n()->__('Message from smartphone');
+    $object->subject = str_replace(self::SMARTPHONE_SUBJECT, $replacement, $object->subject);
+
+    $event->set('data', $object);
   }
 }

--- a/web/js/smt-message.js
+++ b/web/js/smt-message.js
@@ -326,7 +326,7 @@ $(document).ready(function() {
             .append('<a href="' + data.member.profile_url + '">' + data.member.name + '</a>')
           .end()
             .find('.lastMessage')
-            .append('<a href="' + openpne.baseUrl + 'message/smtChain?id=' + data.member.id + '">' + data.subject + '</a>')
+            .append('<a href="' + openpne.baseUrl + 'message/smtChain?id=' + data.member.id + '">' + data.summary + '</a>')
           .end()
             .find('.message-created-at')
             .attr('title', data.created_at)


### PR DESCRIPTION
PC, 携帯用にメッセージのタイトルにスマホからのメッセージである旨が表示されるように回収しました

Enhancement（機能追加・改善） #3542: PC画面に表示するメッセージのタイトルはスマホからの投稿メッセージであると判別できる文言を設定する - opMessagePlugin - OpenPNE Issue Tracking System
https://redmine.openpne.jp/issues/3542
